### PR TITLE
databricks-client: Python REST client for the Databricks REST API

### DIFF
--- a/Python/.gitattributes
+++ b/Python/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/Python/.gitignore
+++ b/Python/.gitignore
@@ -1,0 +1,129 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+.vscode
+
+# Spark tests artifacts
+metastore_db
+spark-warehouse

--- a/Python/packages/databricks-client/MAINTAINER.md
+++ b/Python/packages/databricks-client/MAINTAINER.md
@@ -1,0 +1,23 @@
+# Package maintainer documentation
+
+## Testing and releasing
+
+
+Create a Databricks workspace for integration testing, and provision a service principal with Contributor permissions on the workspace.
+
+Use tox to run integration tests and release the package to PyPI.
+
+To install tox:
+`pip install tox`
+
+To run tests and release:
+```
+export TENANT_ID=YOUR_AZURE_ACTIVE_DIRECTORY_TENANT_ID
+export CLIENT_ID=YOUR_SERVICE_PRINCIPAL_CLIENT_ID
+export CLIENT_SECRET=YOUR_SERVICE_PRINCIPAL_CLIENT_SECRET
+export DATABRICKS_HOST=https://REGION.azuredatabricks.net/api/2.0
+export DATABRICKS_RG=YOUR_DATABRICKS_WORKSPACE_RESOURCE_GROUP
+export DATABRICKS_WORKSPACE=YOUR_DATABRICKS_WORKSPACE_NAME
+
+tox
+```

--- a/Python/packages/databricks-client/README.md
+++ b/Python/packages/databricks-client/README.md
@@ -1,0 +1,121 @@
+# databricks_client
+
+## About
+
+A REST client for the [Databricks REST API](https://docs.databricks.com/dev-tools/api/latest/index.html).
+
+This module is a thin layer allowing to build HTTP [Requests](https://requests.readthedocs.io/en/master/).
+It does not expose API operations as distinct methods, but rather exposes generic methods allowing
+to build API calls.
+
+The Databricks API sometimes returns 200 error codes and HTML content when the request is not
+properly authenticated. The client intercepts such occurrences (detecting non-JSON returned content)
+and wraps them into an exception.
+
+_This open-source project is not developed by nor affiliated with Databricks._
+
+## Installing
+
+```
+pip install databricks-client
+```
+
+## Usage
+
+```python
+import databricks_client
+
+client = databricks_client.create("https://northeurope.azuredatabricks.net/api/2.0")
+client.auth_pat_token(pat_token)
+clusters_list = client.get('clusters/list')
+for cluster in clusters_list["clusters"]:
+    print(cluster)
+```
+
+## Usage with Azure Active Directory
+
+Note: Azure AD authentication for Databricks is currently in preview.
+
+The client generates short-lived Azure AD tokens. If you need to use your client for longer
+than the lifetime (typically 30 minutes), rerun `client.auth_azuread` periodically.
+
+### Azure AD authentication with Azure CLI
+
+[Install the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest).
+
+```
+pip install databricks-client[azurecli]
+az login
+```
+
+```python
+import databricks_client
+
+client = databricks_client.create("https://northeurope.azuredatabricks.net/api/2.0")
+client.auth_azuread("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Databricks/workspaces/my-workspace")
+# or client.auth_azuread(resource_group="my-rg", workspace_name="my-workspace")
+clusters_list = client.get('clusters/list')
+for cluster in clusters_list["clusters"]:
+    print(cluster)
+```
+
+This is recommended with Azure DevOps Pipelines using the [Azure CLI task](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/azure-cli?view=azure-devops).
+
+### Azure AD authentication with ADAL
+
+```
+pip install databricks-client
+pip install adal
+```
+
+```python
+import databricks_client
+import adal
+
+authority_host_uri = 'https://login.microsoftonline.com'
+authority_uri = authority_host_uri + '/' + tenant_id
+context = adal.AuthenticationContext(authority_uri)
+
+def token_callback(resource):
+    return context.acquire_token_with_client_credentials(resource, client_id, client_secret)["accessToken"]
+
+client = databricks_client.create("https://northeurope.azuredatabricks.net/api/2.0")
+client.auth_azuread("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.Databricks/workspaces/my-workspace", token_callback)
+# or client.auth_azuread(resource_group="my-rg", workspace_name="my-workspace", token_callback=token_callback)
+clusters_list = client.get('clusters/list')
+for cluster in clusters_list["clusters"]:
+    print(cluster)
+```
+
+## Example usages
+
+### Generating a PAT token
+
+```python
+response = client.post(
+    'token/create',
+    json={"lifetime_seconds": 60, "comment": "Unit Test Token"}
+)
+pat_token = response['token_value']
+```
+
+### Uploading a notebook
+
+```python
+import base64
+
+with open(notebook_file, "rb") as f:
+    file_content = f.read()
+
+client.post(
+    'workspace/import',
+    json={
+        "content": base64.b64encode(file_content).decode('ascii'),
+        "path": notebook_path,
+        "overwrite": False,
+        "language": "PYTHON",
+        "format": "SOURCE"
+    }
+)
+```
+

--- a/Python/packages/databricks-client/README.md
+++ b/Python/packages/databricks-client/README.md
@@ -1,4 +1,4 @@
-# databricks_client
+# databricks-client
 
 ## About
 

--- a/Python/packages/databricks-client/databricks_client/__init__.py
+++ b/Python/packages/databricks-client/databricks_client/__init__.py
@@ -1,0 +1,97 @@
+import sys
+import requests
+import json
+from requests.exceptions import HTTPError
+
+
+class DatabricksPayloadException(IOError):
+    """Databricks returned an unexpected payload.
+    """
+
+    def __init__(self, *args, **kwargs):
+        response = kwargs.pop('response', None)
+        self.response = response
+        self.request = kwargs.pop('request', None)
+        if (response is not None and not self.request and
+                hasattr(response, 'request')):
+            self.request = self.response.request
+        super(DatabricksPayloadException, self).__init__(*args, **kwargs)
+
+
+class DatabricksClient(object):
+    def __init__(self, host):
+        self.host = host.strip('/')
+
+    def auth_pat_token(self, pat_token):
+        self.dbricks_auth = {
+            'Authorization': 'Bearer %s' % pat_token
+        }
+
+    def auth_azuread(
+        self,
+        workspace_resource_id=None,
+        token_callback=None,
+        subscription_id=None,
+        resource_group=None,
+        workspace_name=None
+    ):
+        if token_callback is None:
+            from azure.common.credentials import get_azure_cli_credentials
+            credentials, subscription_id = get_azure_cli_credentials()
+
+            def token_callback(resource):
+                return credentials.get_token(resource).token
+        if workspace_resource_id is None:
+            if resource_group is None or workspace_name is None:
+                raise ValueError(
+                    "Either workspace_resource_id or both of "
+                    "resource_group and workspace_name must be provided")
+            if subscription_id is None:
+                raise ValueError("subscription_id must be provided")
+            workspace_resource_id = (
+                '/subscriptions/%s/resourceGroups/%s/providers/'
+                'Microsoft.Databricks/workspaces/%s'
+                % (subscription_id, resource_group, workspace_name)
+            )
+
+        adb_token = token_callback('2ff814a6-3304-4ab8-85cb-cd0e6f879c1d')
+        arm_token = token_callback('https://management.core.windows.net/')
+
+        self.dbricks_auth = {
+            'Authorization': 'Bearer %s' % adb_token,
+            'X-Databricks-Azure-SP-Management-Token': arm_token,
+            'X-Databricks-Azure-Workspace-Resource-Id': workspace_resource_id,
+        }
+
+    def get(self, url, **kwargs):
+        return self.query(requests.get, url, **kwargs)
+
+    def post(self, url, **kwargs):
+        return self.query(requests.post, url, **kwargs)
+
+    def query(self, method, url, **kwargs):
+        response = self.query_raw(method, url, **kwargs)
+        try:
+            return response.json()
+        except json.decoder.JSONDecodeError:
+            sys.stderr.write(response.text)
+            raise DatabricksPayloadException(response=response) from None
+
+    def query_raw(self, method, url, **kwargs):
+        """
+        Run a REST query against the Databricks API.
+        Raises an exception on any non-success response.
+        """
+
+        full_url = self.host + '/' + url.lstrip('/')
+        response = method(full_url, headers=self.dbricks_auth, **kwargs)
+        try:
+            response.raise_for_status()
+        except HTTPError:
+            sys.stderr.write(response.text)
+            raise
+        return response
+
+
+def create(*args, **kwargs):
+    return DatabricksClient(*args, **kwargs)

--- a/Python/packages/databricks-client/setup.py
+++ b/Python/packages/databricks-client/setup.py
@@ -1,0 +1,27 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name='databricks_client',
+    version='0.0.1',
+    author="Alexandre Gattiker",
+    author_email="algattik@microsoft.com",
+    description="REST client for Databricks",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/microsoft/DataOps",
+    packages=setuptools.find_packages(),
+    install_requires=[
+        'requests'
+    ],
+    extras_require={
+        'azurecli':  ["azure-core"]
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+)

--- a/Python/packages/databricks-client/tests/client_test.py
+++ b/Python/packages/databricks-client/tests/client_test.py
@@ -1,0 +1,104 @@
+import databricks_client
+import os
+import pytest
+import requests
+import adal
+from azure.common.credentials import get_azure_cli_credentials
+
+credentials, subscription_id = get_azure_cli_credentials()
+dbricks_api = os.environ["DATABRICKS_HOST"]
+resource_group = os.environ["DATABRICKS_RG"]
+workspace_name = os.environ["DATABRICKS_WORKSPACE"]
+resource_id = (
+    '/subscriptions/%s/resourceGroups/%s/providers/'
+    'Microsoft.Databricks/workspaces/%s' %
+    (subscription_id, resource_group, workspace_name)
+)
+
+
+client_id = os.environ["CLIENT_ID"]
+client_secret = os.environ["CLIENT_SECRET"]
+tenant_id = os.environ["TENANT_ID"]
+
+authority_host_uri = 'https://login.microsoftonline.com'
+authority_uri = authority_host_uri + '/' + tenant_id
+context = adal.AuthenticationContext(authority_uri)
+
+
+def get_clusters_list(client):
+    response = client.get('clusters/list')
+    assert "clusters" in response
+
+
+def test_get_clusters_list():
+    client = databricks_client.create(dbricks_api)
+    client.auth_azuread(workspace_resource_id=resource_id)
+    get_clusters_list(client)
+
+
+def test_query_clusters_list():
+    client = databricks_client.create(dbricks_api)
+    client.auth_azuread(workspace_resource_id=resource_id)
+    response = client.query(
+        requests.get,
+        'clusters/list',
+    )
+    assert "clusters" in response
+
+
+def test_pat_token():
+    client = databricks_client.create(dbricks_api)
+    client.auth_azuread(workspace_resource_id=resource_id)
+    response = client.post(
+        'token/create',
+        json={"lifetime_seconds": 60, "comment": "Unit Test Token"}
+    )
+    pat_client = databricks_client.create(client.host)
+    pat_client.auth_pat_token(response['token_value'])
+    get_clusters_list(pat_client)
+
+
+def test_rethrows_http_error():
+    client = databricks_client.create(dbricks_api)
+    client.auth_pat_token("dapi0000000")
+    with pytest.raises(requests.exceptions.HTTPError):
+        get_clusters_list(client)
+
+
+def test_throws_exception_on_non_json_response():
+    client = databricks_client.create(dbricks_api)
+    resource_id = (
+        '/subscriptions/%s/resourceGroups/%s/providers/'
+        'Microsoft.Databricks/workspaces/%s' %
+        (subscription_id, resource_group, 'dummydummy')
+    )
+    client.auth_azuread(workspace_resource_id=resource_id)
+    with pytest.raises(databricks_client.DatabricksPayloadException):
+        get_clusters_list(client)
+
+
+def test_workspace_name():
+    client = databricks_client.create(dbricks_api)
+    client.auth_azuread(
+        resource_group=resource_group, workspace_name=workspace_name)
+    get_clusters_list(client)
+
+
+def test_credentials(mocker):
+    get_cred = mocker.patch(
+        "azure.common.credentials.get_azure_cli_credentials")
+    client = databricks_client.create(dbricks_api)
+
+    client.auth_azuread(resource_id, lambda r: credentials.get_token(r).token)
+    get_clusters_list(client)
+    get_cred.assert_not_called()
+
+
+def test_credentials_msrest():
+    client = databricks_client.create(dbricks_api)
+
+    def token_callback(resource):
+        return context.acquire_token_with_client_credentials(
+            resource, client_id, client_secret)["accessToken"]
+    client.auth_azuread(resource_id, token_callback)
+    get_clusters_list(client)

--- a/Python/packages/databricks-client/tox.ini
+++ b/Python/packages/databricks-client/tox.ini
@@ -1,0 +1,32 @@
+[tox]
+skipsdist = True
+
+[flake8]
+# ignore obsolete warning
+ignore = W503
+exclude = .git,__pycache__,.venv,.tox
+
+[pytest]
+junit_family = legacy
+
+[testenv]
+passenv = 
+  TENANT_ID
+  CLIENT_ID
+  CLIENT_SECRET
+  DATABRICKS_HOST
+  DATABRICKS_RG
+  DATABRICKS_WORKSPACE
+
+deps =
+    adal
+    azure-core
+    azure-common
+    azure-cli
+    msrestazure
+    pytest
+    pytest-mock
+    twine
+commands =
+    pytest
+    twine upload dist/*


### PR DESCRIPTION
This module is a thin layer allowing to build HTTP [Requests](https://requests.readthedocs.io/en/master/) to the Databricks REST API.

It supports authentication with PAT, AAD Service Principal as well as Azure CLI.

Released to PyPI: https://pypi.org/project/databricks-client/

